### PR TITLE
Add additional colors from other RimWorld coloring mods

### DIFF
--- a/SolutionItems/Deploy.bat
+++ b/SolutionItems/Deploy.bat
@@ -3,21 +3,21 @@ REM %1 should be the $(ProjectDir) macro in msbuild.
 REM %2 should be the $(OutDir) macro in msbuild.
 
 SET _defs=Defs
-IF EXIST %~dp1%_defs% (
-    xcopy /i /e /d /y %~dp1%_defs% %~dp2..\%_defs%
+IF EXIST "%~dp1%_defs%" (
+    xcopy /i /e /d /y "%~dp1%_defs% %~dp2..\%_defs%"
 )
 
 SET _languages=Languages
-IF EXIST %~dp1%_languages% (
-    xcopy /i /e /d /y %~dp1%_languages% %~dp2..\%_languages%
+IF EXIST "%~dp1%_languages%" (
+    xcopy /i /e /d /y "%~dp1%_languages% %~dp2..\%_languages%"
 )
 
 SET _patches=Patches
-IF EXIST %~dp1%_patches% (
-    xcopy /i /e /d /y %~dp1%_patches% %~dp2..\%_patches%
+IF EXIST "%~dp1%_patches%" (
+    xcopy /i /e /d /y "%~dp1%_patches% %~dp2..\%_patches%"
 )
 
 SET _textures=Textures
-IF EXIST %~dp1%_textures% (
-    xcopy /i /e /d /y %~dp1%_textures% %~dp2..\%_textures%
+IF EXIST "%~dp1%_textures%" (
+    xcopy /i /e /d /y "%~dp1%_textures% %~dp2..\%_textures%"
 )

--- a/src/About/About.xml
+++ b/src/About/About.xml
@@ -11,4 +11,12 @@
     <supportedVersions>
         <li>1.1</li>
     </supportedVersions>
+    <modDependencies>
+        <li>
+            <packageId>brrainz.harmony</packageId>
+            <displayName>Harmony</displayName>
+            <steamWorkshopUrl>steam://url/CommunityFilePage/2009463077</steamWorkshopUrl>
+            <downloadUrl>https://github.com/pardeike/HarmonyRimWorld/releases/latest</downloadUrl>
+        </li>
+    </modDependencies>
 </ModMetaData>

--- a/src/Common/AwesomeInventory.Base.csproj
+++ b/src/Common/AwesomeInventory.Base.csproj
@@ -93,7 +93,6 @@
       call "$(SolutionDir)SolutionItems\Deploy.bat" "$(ProjectDir)" "$(OutDir)"
       xcopy /d /y " $(SolutionDir)src\LoadFolders.xml" "$(OutDir)..\..\."
       xcopy /i /e /d /y "$(SolutionDir)src\About" "$(OutDir)..\..\About"
-      xcopy /i /d /y "$(SolutionDir)packages\Lib.Harmony.2.0.0.8\lib\net472\*" "$(OutDir)..\..\Common\Assemblies"
     </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/Common/AwesomeInventory.Base.csproj
+++ b/src/Common/AwesomeInventory.Base.csproj
@@ -89,9 +89,11 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>call $(SolutionDir)SolutionItems\Deploy.bat $(ProjectDir) $(OutDir)
-xcopy /d /y $(SolutionDir)src\LoadFolders.xml $(OutDir)..\..\.
-xcopy /i /e /d /y $(SolutionDir)src\About $(OutDir)..\..\About
-xcopy /i /d /y $(SolutionDir)packages\Lib.Harmony.2.0.0.8\lib\net472\* $(OutDir)..\..\Common\Assemblies</PostBuildEvent>
+    <PostBuildEvent>
+      call "$(SolutionDir)SolutionItems\Deploy.bat" "$(ProjectDir)" "$(OutDir)"
+      xcopy /d /y " $(SolutionDir)src\LoadFolders.xml" "$(OutDir)..\..\."
+      xcopy /i /e /d /y "$(SolutionDir)src\About" "$(OutDir)..\..\About"
+      xcopy /i /d /y "$(SolutionDir)packages\Lib.Harmony.2.0.0.8\lib\net472\*" "$(OutDir)..\..\Common\Assemblies"
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/src/V1.1/Common/Common1.1.csproj
+++ b/src/V1.1/Common/Common1.1.csproj
@@ -287,7 +287,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>call $(SolutionDir)SolutionItems\Deploy.bat $(ProjectDir) $(OutDir)</PostBuildEvent>
+    <PostBuildEvent>call "$(SolutionDir)SolutionItems\Deploy.bat" "$(ProjectDir)" "$(OutDir)"</PostBuildEvent>
   </PropertyGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/V1.1/Common/GearTab/DrawGearTabWorker.cs
+++ b/src/V1.1/Common/GearTab/DrawGearTabWorker.cs
@@ -374,6 +374,7 @@ namespace AwesomeInventory.UI
         /// <param name="rect"> Position on screen. </param>
         protected static void DrawQualityFrame(ThingWithComps thing, Rect rect)
         {
+            // TODO: use a mod setting to determine which theme to use
             if (thing.TryGetQuality(out QualityCategory c))
             {
                 switch (c)

--- a/src/V1.1/Common/UI/AwesomeInventoryTex.cs
+++ b/src/V1.1/Common/UI/AwesomeInventoryTex.cs
@@ -21,10 +21,32 @@ namespace AwesomeInventory.UI
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 #pragma warning disable SA1600 // Elements should be documented
 
+        /************
+         *  Colors  *
+         ************/
         public static readonly Color Valvet = GenColor.FromHex("cc1a00");
         public static readonly Color LightGrey = GenColor.FromHex("b0b3af");
         public static readonly Color RWPrimaryColor = GenColor.FromHex("6a512e");
 
+        // For Lighter Colorful Traits
+        public static readonly Color LCT_MediumPurple = GenColor.FromHex("9370DB");
+        public static readonly Color LCT_Olivine = GenColor.FromHex("9AB973");
+        public static readonly Color LCT_CanaryYellow = GenColor.FromHex("FFFF99");
+        public static readonly Color LCT_AtomicTangerine = GenColor.FromHex("FF9966");
+        public static readonly Color LCT_PantoneRed = GenColor.FromHex("ED2939");
+
+        // For Color Coded Mood Bar
+        private static float colorAlpha = 0.44f;
+        public static readonly Color CCMB_HappyColor = new Color(0.1f, 0.75f, 0.2f, colorAlpha);
+        public static readonly Color CCMB_Cyan = new Color(Color.cyan.r, Color.cyan.g, Color.cyan.b, colorAlpha);
+        public static readonly Color CCMB_NeutralColor = new Color(0.87f, 0.96f, 0.79f, colorAlpha);
+        public static readonly Color CCMB_Yellow = new Color(Color.yellow.r, Color.yellow.g, Color.yellow.b, colorAlpha);
+        public static readonly Color CCMB_Orange = new Color(1f, 0.5f, 0.31f, colorAlpha);
+        public static readonly Color CCMB_Red = new Color(Color.red.r, Color.red.g, Color.red.b, colorAlpha);
+
+        /************
+         * Textures *
+         ************/
         public static readonly Texture OrangeTex = SolidColorMaterials.NewSolidColorTexture(ColorLibrary.Orange);
         public static readonly Texture CyanTex = SolidColorMaterials.NewSolidColorTexture(ColorLibrary.Cyan);
         public static readonly Texture BrightPurpleTex = SolidColorMaterials.NewSolidColorTexture(ColorLibrary.BrightPurple);
@@ -47,6 +69,24 @@ namespace AwesomeInventory.UI
         public static readonly Texture Normal = BaseContent.WhiteTex;
         public static readonly Texture Poor = LightGreyTex;
         public static readonly Texture Awful = ValvetTex;
+
+        // For Lighter Colorful Traits
+        public static readonly Texture LCT_Lengendary = SolidColorMaterials.NewSolidColorTexture(LCT_MediumPurple);
+        public static readonly Texture LCT_Masterwork = CyanTex; // TODO: possibly tweak this?
+        public static readonly Texture LCT_Excellent = SolidColorMaterials.NewSolidColorTexture(LCT_Olivine);
+        public static readonly Texture LCT_Good = BaseContent.WhiteTex;
+        public static readonly Texture LCT_Normal = SolidColorMaterials.NewSolidColorTexture(LCT_CanaryYellow);
+        public static readonly Texture LCT_Poor = SolidColorMaterials.NewSolidColorTexture(LCT_AtomicTangerine);
+        public static readonly Texture LCT_Awful = SolidColorMaterials.NewSolidColorTexture(LCT_PantoneRed);
+
+        // For Color Coded Mood Bar
+        public static readonly Texture CCMB_Lengendary = BrightPurpleTex; // TODO: possibly tweak this?
+        public static readonly Texture CCMB_Masterwork = SolidColorMaterials.NewSolidColorTexture(CCMB_HappyColor);
+        public static readonly Texture CCMB_Excellent = SolidColorMaterials.NewSolidColorTexture(CCMB_Cyan);
+        public static readonly Texture CCMB_Good = SolidColorMaterials.NewSolidColorTexture(CCMB_NeutralColor);
+        public static readonly Texture CCMB_Normal = SolidColorMaterials.NewSolidColorTexture(CCMB_Yellow);
+        public static readonly Texture CCMB_Poor = SolidColorMaterials.NewSolidColorTexture(CCMB_Orange);
+        public static readonly Texture CCMB_Awful = SolidColorMaterials.NewSolidColorTexture(CCMB_Red);
 
 #pragma warning restore SA1600 // Elements should be documented
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/V1.1/Vanilla/Vanilla1.1.csproj
+++ b/src/V1.1/Vanilla/Vanilla1.1.csproj
@@ -323,10 +323,9 @@
     <Error Condition="!Exists('..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.2.9.8\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
   </Target>
   <PropertyGroup>
-    <PostBuildEvent>call $(SolutionDir)SolutionItems\Deploy.bat $(ProjectDir) $(OutDir)
-            
-            
-</PostBuildEvent>
+    <PostBuildEvent>
+      call "$(SolutionDir)SolutionItems\Deploy.bat" "$(ProjectDir)" "$(OutDir)"
+    </PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>


### PR DESCRIPTION
Adds colors from [Lighter Colorful Traits](https://steamcommunity.com/sharedfiles/filedetails/?id=2012333189) and [Color Coded Mood Bar](https://steamcommunity.com/sharedfiles/filedetails/?id=1136819681). Note that this PR does not actually use the colors, as that should be set up via the mod settings.