### PR TITLE
Fix error when a Pawn_OutfitTracker has a null pawn

### DIFF
--- a/src/V1.1/Common/HarmonyPatches/Pawn_OutfitTracker_CurrentOutfit.cs
+++ b/src/V1.1/Common/HarmonyPatches/Pawn_OutfitTracker_CurrentOutfit.cs
@@ -34,7 +34,7 @@ namespace AwesomeInventory.HarmonyPatches
         [SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "Postfix patch")]
         public static void Postfix(Outfit value, Pawn_OutfitTracker __instance)
         {
-            if (__instance != null)
+            if (__instance?.pawn != null)
             {
                 if (value is AwesomeInventoryLoadout loadout)
                     __instance.pawn.SetLoadout(loadout);


### PR DESCRIPTION
In my heavily modded setup, for some reason, Pawn_OutfitTracker.pawn ended up being null. This completely prevented me from opening the Assign tab in the game. This fixes the error when that happens for whatever reason.